### PR TITLE
Improve review page design with pagination

### DIFF
--- a/src/main/java/com/exampleepam/restaurant/controller/DishReviewController.java
+++ b/src/main/java/com/exampleepam/restaurant/controller/DishReviewController.java
@@ -2,6 +2,7 @@ package com.exampleepam.restaurant.controller;
 
 import com.exampleepam.restaurant.dto.dish.DishResponseDto;
 import com.exampleepam.restaurant.dto.review.ReviewDto;
+import com.exampleepam.restaurant.entity.paging.Paged;
 import com.exampleepam.restaurant.service.DishService;
 import com.exampleepam.restaurant.service.ReviewService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,8 +10,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
-import java.util.List;
 
 @Controller
 public class DishReviewController extends BaseController {
@@ -25,12 +26,24 @@ public class DishReviewController extends BaseController {
     }
 
     @GetMapping("/dishes/{dishId}/reviews")
-    public String viewDishReviews(@PathVariable Long dishId, Model model) {
+    public String viewDishReviews(@PathVariable Long dishId,
+                                  @RequestParam(value = "page", defaultValue = "1") int page,
+                                  @RequestParam(value = "size", defaultValue = "4") int size,
+                                  @RequestParam(value = "sort", defaultValue = "new") String sort,
+                                  @RequestParam(value = SORT_FIELD_PARAM, required = false, defaultValue = "name") String sortField,
+                                  @RequestParam(value = SORT_DIR_PARAM, required = false, defaultValue = ASCENDING_ORDER_SORTING) String sortDir,
+                                  @RequestParam(value = FILTER_CATEGORY_PARAM, required = false, defaultValue = "all") String filterCategory,
+                                  Model model) {
         DishResponseDto dish = dishService.getDishById(dishId);
         dish.setAverageRating(reviewService.getAverageRatingForDish(dishId));
-        List<ReviewDto> reviews = reviewService.getReviewsForDish(dishId);
+        Paged<ReviewDto> reviews = reviewService.getPaginatedReviewsForDish(dishId, page, size, sort);
         model.addAttribute("dish", dish);
-        model.addAttribute("reviews", reviews);
+        model.addAttribute("reviewPaged", reviews);
+        model.addAttribute("pageSize", size);
+        model.addAttribute("reviewSort", sort);
+        model.addAttribute(SORT_FIELD_PARAM, sortField);
+        model.addAttribute(SORT_DIR_PARAM, sortDir);
+        model.addAttribute(FILTER_CATEGORY_PARAM, filterCategory);
         return "dish-reviews";
     }
 }

--- a/src/main/java/com/exampleepam/restaurant/dto/review/ReviewDto.java
+++ b/src/main/java/com/exampleepam/restaurant/dto/review/ReviewDto.java
@@ -5,6 +5,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import java.time.LocalDateTime;
+
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
@@ -34,4 +36,9 @@ public class ReviewDto {
      * but used for displaying reviews on the site.
      */
     private String userName;
+
+    /**
+     * Timestamp when the review was created.
+     */
+    private LocalDateTime creationDateTime;
 }

--- a/src/main/java/com/exampleepam/restaurant/mapper/ReviewMapper.java
+++ b/src/main/java/com/exampleepam/restaurant/mapper/ReviewMapper.java
@@ -40,6 +40,7 @@ public class ReviewMapper {
         dto.setId(review.getId() == null ? 0 : review.getId());
         dto.setRating(review.getRating());
         dto.setComment(review.getComment());
+        dto.setCreationDateTime(review.getCreationDateTime());
         if (review.getUser() != null) {
             dto.setUserName(review.getUser().getName());
         }

--- a/src/main/java/com/exampleepam/restaurant/repository/ReviewRepository.java
+++ b/src/main/java/com/exampleepam/restaurant/repository/ReviewRepository.java
@@ -8,11 +8,15 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     List<Review> findAllByDishId(Long dishId);
+
+    Page<Review> findAllByDishId(Long dishId, Pageable pageable);
 
     List<Review> findAllByUserId(Long userId);
 

--- a/src/main/java/com/exampleepam/restaurant/service/ReviewService.java
+++ b/src/main/java/com/exampleepam/restaurant/service/ReviewService.java
@@ -12,6 +12,12 @@ import com.exampleepam.restaurant.mapper.ReviewMapper;
 import com.exampleepam.restaurant.repository.DishRepository;
 import com.exampleepam.restaurant.repository.OrderRepository;
 import com.exampleepam.restaurant.repository.ReviewRepository;
+import com.exampleepam.restaurant.entity.paging.Paged;
+import com.exampleepam.restaurant.entity.paging.Paging;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import com.exampleepam.restaurant.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -116,6 +122,17 @@ public class ReviewService {
                 .stream()
                 .map(reviewMapper::toDto)
                 .toList();
+    }
+
+    public Paged<ReviewDto> getPaginatedReviewsForDish(Long dishId, int page, int size, String sort) {
+        Sort sortObj = switch (sort) {
+            case "rating" -> Sort.by(Sort.Direction.DESC, "rating");
+            default -> Sort.by(Sort.Direction.DESC, "creationDateTime");
+        };
+        Pageable pageable = PageRequest.of(page - 1, size, sortObj);
+        Page<Review> reviewPage = reviewRepository.findAllByDishId(dishId, pageable);
+        Page<ReviewDto> dtoPage = reviewPage.map(reviewMapper::toDto);
+        return new Paged<>(dtoPage, Paging.of(reviewPage.getTotalPages(), page, size));
     }
 
     public double getAverageRatingForDish(Long dishId) {

--- a/src/main/resources/static/js/menu-scroll.js
+++ b/src/main/resources/static/js/menu-scroll.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const pos = localStorage.getItem('menuScrollPos');
+    if (pos) {
+        window.scrollTo(0, parseInt(pos));
+        localStorage.removeItem('menuScrollPos');
+    }
+});
+window.addEventListener('beforeunload', function() {
+    localStorage.setItem('menuScrollPos', window.scrollY);
+});

--- a/src/main/resources/templates/dish-reviews.html
+++ b/src/main/resources/templates/dish-reviews.html
@@ -8,37 +8,67 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <style>
         body {
-            background: linear-gradient(rgba(0, 0, 0, 0.85), rgba(0, 0, 0, 0.85)),
-            url('../images/saveInPhotoshop.png') no-repeat center center;
+            background: linear-gradient(rgba(0, 0, 0, 0.93), rgba(0, 0, 0, 0.93)),
+            url('/images/saveInPhotoshop.png') no-repeat;
             background-size: cover;
         }
 
         .review-wrapper {
             max-width: 800px;
             margin: 40px auto;
-            background: #fff;
+            background: rgba(255,255,255,0.95);
             border-radius: 8px;
             padding: 2rem;
             box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
         }
 
         .review-card {
-            background: #f8f9fa;
+            position: relative;
+            background: #ffffff;
             border-radius: 8px;
-            padding: 1rem;
-            margin-bottom: 1rem;
+            padding: 1.5rem;
+            margin-bottom: 1.5rem;
             box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+            border-left: 4px solid #343a40;
+        }
+        .review-card::before {
+            content: "\201C";
+            position: absolute;
+            top: -10px;
+            left: 10px;
+            font-family: Georgia, serif;
+            font-size: 3rem;
+            color: #343a40;
+            line-height: 1;
+        }
+        .review-date {
+            font-size: 0.85rem;
+            color: #6c757d;
         }
 
         .star-rating i { color: #FFD700; }
+
+        .pagination { justify-content: center; }
+        .pagination .page-link {
+            color: #343a40;
+            border-color: #343a40;
+        }
+        .pagination .page-item.active .page-link {
+            background-color: #343a40;
+            border-color: #343a40;
+            color: #fff;
+        }
+        .sort-select { width: auto; display: inline-block; }
     </style>
 </head>
 <body>
 <div th:replace="fragments/topnav :: navbar"></div>
 
+<div class="page-wrapper bg-gra-02 p-t-130 p-b-100 font-poppins" id="reviewsBackground">
+<div class="wrapper wrapper--w860">
 <div class="review-wrapper">
     <div class="d-flex justify-content-between align-items-center mb-3">
-        <a href="/menu" class="text-decoration-none text-dark">
+        <a th:href="@{'/menu?sortField=' + ${sortField} + '&sortDir=' + ${sortDir} + '&filterCategory=' + ${filterCategory}}" class="text-decoration-none text-dark">
             <i class="fa fa-arrow-left me-2"></i>Back to menu
         </a>
         <h2 class="flex-grow-1 text-center m-0" th:text="${dish.name}">Dish Name</h2>
@@ -47,33 +77,81 @@
     <div class="text-center mb-3">
         <img th:if="${dish.imageFileName != null}" th:src="@{${dish.getimagePath()}}" class="img-fluid rounded" style="max-width:300px" alt="Dish image">
     </div>
-    <div class="text-center mb-4">
-        <div class="star-rating">
+    <div class="d-flex justify-content-between align-items-center mb-4 flex-wrap">
+        <div class="star-rating mb-2 mb-md-0">
             <span th:each="i : ${#numbers.sequence(1,5)}">
                 <i th:class="${dish.averageRating >= i ? 'fa fa-star' : 'fa fa-star-o'}"></i>
             </span>
             <span class="ms-2" th:text="${#numbers.formatDecimal(dish.averageRating,1,1)}"></span>
         </div>
+        <form id="sortForm" method="get">
+            <input type="hidden" name="page" value="1"/>
+            <input type="hidden" name="size" th:value="${pageSize}"/>
+            <input type="hidden" name="sortField" th:value="${sortField}"/>
+            <input type="hidden" name="sortDir" th:value="${sortDir}"/>
+            <input type="hidden" name="filterCategory" th:value="${filterCategory}"/>
+            <select name="sort" class="form-select sort-select" onchange="document.getElementById('sortForm').submit()">
+                <option value="new" th:selected="${reviewSort == 'new'}">Newest</option>
+                <option value="rating" th:selected="${reviewSort == 'rating'}">Rating high-low</option>
+            </select>
+        </form>
     </div>
 
-    <div th:if="${reviews.size() > 0}">
-        <div th:each="rev : ${reviews}" class="review-card">
+    <div th:if="${reviewPaged.page.content.size() > 0}">
+        <div th:each="rev : ${reviewPaged.page}" class="review-card">
             <div>
                 <span th:each="i : ${#numbers.sequence(1,5)}">
                     <i th:class="${rev.rating >= i ? 'fa fa-star text-warning' : 'fa fa-star-o text-warning'}"></i>
                 </span>
             </div>
             <p class="fw-bold mb-1" th:text="${rev.userName}">User Name</p>
+            <p class="review-date" th:text="${#temporals.format(rev.creationDateTime, 'dd MMM yyyy HH:mm')}"></p>
             <p th:if="${rev.comment != null and !#strings.isEmpty(rev.comment)}" class="mt-2 mb-0" th:text="${rev.comment}">Comment</p>
             <form sec:authorize="hasAuthority('ADMIN')" th:method="delete"
                   th:action="@{'/admin/reviews/' + ${rev.id} + '?dishId=' + ${dish.id}}" class="mt-2">
                 <button type="submit" class="btn btn-sm btn-danger">Delete</button>
             </form>
         </div>
+        <nav aria-label="Page navigation" th:if="${reviewPaged.paging.totalPages > 1}">
+            <ul class="pagination">
+                <li class="page-item" th:classappend="${!reviewPaged.paging.isPrevEnabled()? 'disabled' : ''}">
+                    <a class="page-link"
+                       th:href="@{'/dishes/' + ${dish.id} + '/reviews?page=' + (${reviewPaged.paging.pageNumber - 1}) + '&size=' + ${pageSize} + '&sort=' + ${reviewSort} + '&sortField=' + ${sortField} + '&sortDir=' + ${sortDir} + '&filterCategory=' + ${filterCategory}}"
+                       tabindex="-1" th:text="#{pagination.previous}">Previous</a>
+                </li>
+                <th:block th:each="item : ${reviewPaged.paging.getItems()}">
+                    <li class="page-item"
+                        th:classappend="${item.index == reviewPaged.paging.pageNumber? 'active' : ''}"
+                        th:if="${item.pageItemType.name() == 'PAGE'}">
+                        <a class="page-link"
+                           th:href="@{'/dishes/' + ${dish.id} + '/reviews?page=' + ${item.index} + '&size=' + ${pageSize} + '&sort=' + ${reviewSort} + '&sortField=' + ${sortField} + '&sortDir=' + ${sortDir} + '&filterCategory=' + ${filterCategory}}"
+                           th:text="${item.index}"></a>
+                    </li>
+                    <li class="page-item disabled" th:if="${item.pageItemType.name() == 'DOTS'}">
+                        <a class="page-link" href="#">...</a>
+                    </li>
+                </th:block>
+                <li class="page-item" th:classappend="${!reviewPaged.paging.isNextEnabled()? 'disabled' : ''}">
+                    <a class="page-link"
+                       th:href="@{'/dishes/' + ${dish.id} + '/reviews?page=' + (${reviewPaged.paging.pageNumber + 1}) + '&size=' + ${pageSize} + '&sort=' + ${reviewSort} + '&sortField=' + ${sortField} + '&sortDir=' + ${sortDir} + '&filterCategory=' + ${filterCategory}}"
+                       th:text="#{pagination.next}">Next</a>
+                </li>
+            </ul>
+        </nav>
     </div>
-    <div th:unless="${reviews.size() > 0}" class="text-center">
+    <div th:unless="${reviewPaged.page.content.size() > 0}" class="text-center">
         <p>No reviews for this dish yet.</p>
     </div>
 </div>
+</div>
+</div>
+<script>
+    document.getElementById('reviewsBackground').addEventListener('click', function (e) {
+        const container = document.querySelector('.review-wrapper');
+        if (container && !container.contains(e.target)) {
+            window.location.href = '/menu';
+        }
+    });
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/dishCard.html
+++ b/src/main/resources/templates/fragments/dishCard.html
@@ -21,7 +21,7 @@
             <span th:each="i : ${#numbers.sequence(1,5)}">
                 <i th:class="${dish.averageRating >= i ? 'fa fa-star text-warning' : 'fa fa-star-o text-warning'}"></i>
             </span>
-            <a th:href="@{/dishes/{id}/reviews(id=${dish.id})}" class="ms-2 link-light">Reviews</a>
+            <a th:href="@{'/dishes/' + ${dish.id} + '/reviews?sortField=' + ${sortField} + '&sortDir=' + ${sortDir} + '&filterCategory=' + ${filterCategory}}" class="ms-2 link-light">Reviews</a>
         </div>
 
         <div class="myContainer m-1">

--- a/src/main/resources/templates/menu.html
+++ b/src/main/resources/templates/menu.html
@@ -119,5 +119,6 @@
 </script>
 
 <script type="text/javascript" th:src="@{/js/button.js}"></script>
+<script type="text/javascript" th:src="@{/js/menu-scroll.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/review.html
+++ b/src/main/resources/templates/review.html
@@ -21,12 +21,13 @@
             href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
             rel="stylesheet"
     />
+    <link rel="stylesheet" type="text/css" href="/css/form.css"/>
 
     <style>
         /* Dark gradient background + your image */
         body {
             background: linear-gradient(rgba(0, 0, 0, 0.93), rgba(0, 0, 0, 0.93)),
-            url("../images/saveInPhotoshop.png") no-repeat;
+            url("/images/saveInPhotoshop.png") no-repeat;
             background-size: cover;
 
             color: #fff; /* for text outside the container */
@@ -139,7 +140,11 @@
 
 <div th:replace="fragments/topnav :: navbar"></div>
 
+<div id="reviewBackground">
 <div class="review-container">
+    <a href="/orders/history" class="text-decoration-none text-dark mb-3 d-inline-block">
+        <i class="fa fa-arrow-left me-2"></i>Back to order history
+    </a>
     <h2 class="review-title">
         <span th:text="#{review.multiple.form.title}">Review your order</span>
         #<span th:text="${orderId}">OrderID</span>
@@ -193,7 +198,8 @@
                 <span th:text="#{review.submit.button}">Submit</span>
             </button>
         </div>
-    </form>
+</form>
+</div>
 </div>
 
 <!-- Bootstrap Bundle -->
@@ -251,6 +257,13 @@
             star.style.color = '#FBC02D';  // revert to unselected color
         });
     }
+
+    document.getElementById('reviewBackground').addEventListener('click', function(e) {
+        const container = document.querySelector('.review-container');
+        if (container && !container.contains(e.target)) {
+            window.location.href = '/menu';
+        }
+    });
 </script>
 
 </body>


### PR DESCRIPTION
## Summary
- update menu page to restore scroll position
- link to reviews with current sort and filter
- add pagination-aware review retrieval in controller and service
- update repository for pageable access
- enhance dish reviews template design and pagination

## Testing
- `sh mvnw -q -DskipTests compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_687bcf6edec0833388bfe61452d3092c